### PR TITLE
fixes Bug 1040358 -- powertool doesn't correctly autodetect the mozilla ...

### DIFF
--- a/powertool/mozilla.py
+++ b/powertool/mozilla.py
@@ -68,7 +68,7 @@ class MozillaDevice(threading.Thread):
 
     def _scanForDevice(self):
         # get the list of os-specific serial port names that have a Mozilla ammeter connected to them
-        ports = [p[0] for p in serial.tools.list_ports.comports() if p[2].lower().startswith('usb vid:pid=03eb:204b')]
+        ports = [p[0] for p in serial.tools.list_ports.comports() if p[2].lower().startswith('usb vid:pid=03eb:204b') or p[2].lower().startswith('usb vid:pid=3eb:204b')]
         if len(ports) > 0:
             print "Found Mozilla Ammeter attached to: %s" % ports[0]
             return ports[0]


### PR DESCRIPTION
...ammeter on mac os x

tested on my mac running mac os x 10.9.4 with python 2.7.8
